### PR TITLE
Update to use MSAL (v2 Azure OAuth endpoints)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /packages
 /ExcelBotEmbedded/ExcelBotEmbedded/bin
 /.vs
+ExcelBot/PrivateSettings.config

--- a/ExcelBot/App_Start/WebApiConfig.cs
+++ b/ExcelBot/App_Start/WebApiConfig.cs
@@ -2,12 +2,9 @@
  * Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
  * See LICENSE in the project root for license information.
  */
- 
+
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Web.Http;
 
 namespace ExcelBot

--- a/ExcelBot/ApplicationInsights.config
+++ b/ExcelBot/ApplicationInsights.config
@@ -3,80 +3,18 @@
 <!-- See LICENSE in the project root for license information -->
 <ApplicationInsights xmlns="http://schemas.microsoft.com/ApplicationInsights/2013/Settings">
   <InstrumentationKey>YOUR APPLICATION INSIGHTS KEY</InstrumentationKey>
-  <TelemetryProcessors>
-		<Add Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryProcessor, Microsoft.AI.PerfCounterCollector"/>
-		<Add Type="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.AdaptiveSamplingTelemetryProcessor, Microsoft.AI.ServerTelemetryChannel">
-			<MaxTelemetryItemsPerSecond>5</MaxTelemetryItemsPerSecond>
-		</Add>
-	</TelemetryProcessors>
-	<TelemetryModules>
-		<Add Type="Microsoft.ApplicationInsights.DependencyCollector.DependencyTrackingTelemetryModule, Microsoft.AI.DependencyCollector"/>
-		<Add Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.PerformanceCollectorModule, Microsoft.AI.PerfCounterCollector">
-			<!--
-      Use the following syntax here to collect additional performance counters:
-      
-      <Counters>
-        <Add PerformanceCounter="\Process(??APP_WIN32_PROC??)\Handle Count" ReportAs="Process handle count" />
-        ...
-      </Counters>
-      
-      PerformanceCounter must be either \CategoryName(InstanceName)\CounterName or \CategoryName\CounterName
-      
-      Counter names may only contain letters, round brackets, forward slashes, hyphens, underscores, spaces and dots.
-      You may provide an optional ReportAs attribute which will be used as the metric name when reporting counter data.
-      For the purposes of reporting, metric names will be sanitized by removing all invalid characters from the resulting metric name.
-      
-      NOTE: performance counters configuration will be lost upon NuGet upgrade.
-      
-      The following placeholders are supported as InstanceName:
-        ??APP_WIN32_PROC?? - instance name of the application process  for Win32 counters.
-        ??APP_W3SVC_PROC?? - instance name of the application IIS worker process for IIS/ASP.NET counters.
-        ??APP_CLR_PROC?? - instance name of the application CLR process for .NET counters.
-      -->
-		</Add>
-		<Add Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryModule, Microsoft.AI.PerfCounterCollector"/>
-		<Add Type="Microsoft.ApplicationInsights.WindowsServer.DeveloperModeWithDebuggerAttachedTelemetryModule, Microsoft.AI.WindowsServer"/>
-		<Add Type="Microsoft.ApplicationInsights.WindowsServer.UnhandledExceptionTelemetryModule, Microsoft.AI.WindowsServer"/>
-		<Add Type="Microsoft.ApplicationInsights.WindowsServer.UnobservedExceptionTelemetryModule, Microsoft.AI.WindowsServer"/>
-		<Add Type="Microsoft.ApplicationInsights.Web.RequestTrackingTelemetryModule, Microsoft.AI.Web">
-			<Handlers>
-				<!-- 
-        Add entries here to filter out additional handlers: 
-        
-        NOTE: handler configuration will be lost upon NuGet upgrade.
-        -->
-				<Add>System.Web.Handlers.TransferRequestHandler</Add>
-				<Add>Microsoft.VisualStudio.Web.PageInspector.Runtime.Tracing.RequestDataHttpHandler</Add>
-				<Add>System.Web.StaticFileHandler</Add>
-				<Add>System.Web.Handlers.AssemblyResourceLoader</Add>
-				<Add>System.Web.Optimization.BundleHandler</Add>
-				<Add>System.Web.Script.Services.ScriptHandlerFactory</Add>
-				<Add>System.Web.Handlers.TraceHandler</Add>
-				<Add>System.Web.Services.Discovery.DiscoveryRequestHandler</Add>
-				<Add>System.Web.HttpDebugHandler</Add>
-			</Handlers>
-		</Add>
-		<Add Type="Microsoft.ApplicationInsights.Web.ExceptionTrackingTelemetryModule, Microsoft.AI.Web"/>
-	</TelemetryModules>
-	<TelemetryChannel Type="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.ServerTelemetryChannel, Microsoft.AI.ServerTelemetryChannel"/>
-<!-- 
-    Learn more about Application Insights configuration with ApplicationInsights.config here: 
-    http://go.microsoft.com/fwlink/?LinkID=513840
-    
-    Note: If not present, please add <InstrumentationKey>Your Key</InstrumentationKey> to the top of this file.
-  -->
+
 <TelemetryInitializers>
-<Add Type="Microsoft.ApplicationInsights.WindowsServer.AzureRoleEnvironmentTelemetryInitializer, Microsoft.AI.WindowsServer"/>
 <Add Type="Microsoft.ApplicationInsights.WindowsServer.DomainNameRoleInstanceTelemetryInitializer, Microsoft.AI.WindowsServer"/>
+<Add Type="Microsoft.ApplicationInsights.DependencyCollector.HttpDependenciesParsingTelemetryInitializer, Microsoft.AI.DependencyCollector"/>
+<Add Type="Microsoft.ApplicationInsights.WindowsServer.AzureRoleEnvironmentTelemetryInitializer, Microsoft.AI.WindowsServer"/>
+<Add Type="Microsoft.ApplicationInsights.WindowsServer.AzureWebAppRoleEnvironmentTelemetryInitializer, Microsoft.AI.WindowsServer"/>
 <Add Type="Microsoft.ApplicationInsights.WindowsServer.BuildInfoConfigComponentVersionTelemetryInitializer, Microsoft.AI.WindowsServer"/>
 <Add Type="Microsoft.ApplicationInsights.Web.WebTestTelemetryInitializer, Microsoft.AI.Web"/>
 <Add Type="Microsoft.ApplicationInsights.Web.SyntheticUserAgentTelemetryInitializer, Microsoft.AI.Web">
-<Filters>
-<Add Pattern="(YottaaMonitor|BrowserMob|HttpMonitor|YandexBot|BingPreview|PagePeeker|ThumbShotsBot|WebThumb|URL2PNG|ZooShot|GomezA|Catchpoint bot|Willow Internet Crawler|Google SketchUp|Read%20Later|KTXN|Pingdom|AlwaysOn)"/>
-<Add Pattern="Slurp" SourceName="Yahoo Bot"/>
-<Add Pattern="(bot|zao|borg|Bot|oegp|silk|Xenu|zeal|^NING|crawl|Crawl|htdig|lycos|slurp|teoma|voila|yahoo|Sogou|CiBra|Nutch|^Java/|^JNLP/|Daumoa|Genieo|ichiro|larbin|pompos|Scrapy|snappy|speedy|spider|Spider|vortex|favicon|indexer|Riddler|scooter|scraper|scrubby|WhatWeb|WinHTTP|^voyager|archiver|Icarus6j|mogimogi|Netvibes|altavista|charlotte|findlinks|Retreiver|TLSProber|WordPress|wsr\-agent|Squrl Java|A6\-Indexer|netresearch|searchsight|http%20client|Python-urllib|dataparksearch|Screaming Frog|AppEngine-Google|YahooCacheSystem|semanticdiscovery|facebookexternalhit|Google.*/\+/web/snippet|Google-HTTP-Java-Client)"
-SourceName="Spider"/>
-</Filters>
+<!-- Extended list of bots:
+            search|spider|crawl|Bot|Monitor|BrowserMob|BingPreview|PagePeeker|WebThumb|URL2PNG|ZooShot|GomezA|Google SketchUp|Read Later|KTXN|KHTE|Keynote|Pingdom|AlwaysOn|zao|borg|oegp|silk|Xenu|zeal|NING|htdig|lycos|slurp|teoma|voila|yahoo|Sogou|CiBra|Nutch|Java|JNLP|Daumoa|Genieo|ichiro|larbin|pompos|Scrapy|snappy|speedy|vortex|favicon|indexer|Riddler|scooter|scraper|scrubby|WhatWeb|WinHTTP|voyager|archiver|Icarus6j|mogimogi|Netvibes|altavista|charlotte|findlinks|Retreiver|TLSProber|WordPress|wsr-agent|http client|Python-urllib|AppEngine-Google|semanticdiscovery|facebookexternalhit|web/snippet|Google-HTTP-Java-Client-->
+<Filters>search|spider|crawl|Bot|Monitor|AlwaysOn</Filters>
 </Add>
 <Add Type="Microsoft.ApplicationInsights.Web.ClientIpHeaderTelemetryInitializer, Microsoft.AI.Web"/>
 <Add Type="Microsoft.ApplicationInsights.Web.OperationNameTelemetryInitializer, Microsoft.AI.Web"/>
@@ -86,4 +24,88 @@ SourceName="Spider"/>
 <Add Type="Microsoft.ApplicationInsights.Web.AccountIdTelemetryInitializer, Microsoft.AI.Web"/>
 <Add Type="Microsoft.ApplicationInsights.Web.SessionTelemetryInitializer, Microsoft.AI.Web"/>
 </TelemetryInitializers>
-</ApplicationInsights>
+<TelemetryModules>
+<Add Type="Microsoft.ApplicationInsights.DependencyCollector.DependencyTrackingTelemetryModule, Microsoft.AI.DependencyCollector">
+<ExcludeComponentCorrelationHttpHeadersOnDomains>
+<!-- 
+        Requests to the following hostnames will not be modified by adding correlation headers.         
+        Add entries here to exclude additional hostnames.
+        NOTE: this configuration will be lost upon NuGet upgrade.
+        -->
+<Add>core.windows.net</Add>
+<Add>core.chinacloudapi.cn</Add>
+<Add>core.cloudapi.de</Add>
+<Add>core.usgovcloudapi.net</Add>
+<Add>localhost</Add>
+<Add>127.0.0.1</Add>
+</ExcludeComponentCorrelationHttpHeadersOnDomains>
+<IncludeDiagnosticSourceActivities>
+<Add>Microsoft.Azure.EventHubs</Add>
+<Add>Microsoft.Azure.ServiceBus</Add>
+</IncludeDiagnosticSourceActivities>
+</Add>
+<Add Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.PerformanceCollectorModule, Microsoft.AI.PerfCounterCollector">
+<!--
+      Use the following syntax here to collect additional performance counters:
+      
+      <Counters>
+        <Add PerformanceCounter="\Process(??APP_WIN32_PROC??)\Handle Count" ReportAs="Process handle count" />
+        ...
+      </Counters>
+      
+      PerformanceCounter must be either \CategoryName(InstanceName)\CounterName or \CategoryName\CounterName
+      
+      NOTE: performance counters configuration will be lost upon NuGet upgrade.
+      
+      The following placeholders are supported as InstanceName:
+        ??APP_WIN32_PROC?? - instance name of the application process  for Win32 counters.
+        ??APP_W3SVC_PROC?? - instance name of the application IIS worker process for IIS/ASP.NET counters.
+        ??APP_CLR_PROC?? - instance name of the application CLR process for .NET counters.
+      -->
+</Add>
+<Add Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryModule, Microsoft.AI.PerfCounterCollector"/>
+<Add Type="Microsoft.ApplicationInsights.WindowsServer.DeveloperModeWithDebuggerAttachedTelemetryModule, Microsoft.AI.WindowsServer"/>
+<Add Type="Microsoft.ApplicationInsights.WindowsServer.UnhandledExceptionTelemetryModule, Microsoft.AI.WindowsServer"/>
+<Add Type="Microsoft.ApplicationInsights.WindowsServer.UnobservedExceptionTelemetryModule, Microsoft.AI.WindowsServer">
+<!--</Add>
+    <Add Type="Microsoft.ApplicationInsights.WindowsServer.FirstChanceExceptionStatisticsTelemetryModule, Microsoft.AI.WindowsServer">-->
+</Add>
+<Add Type="Microsoft.ApplicationInsights.Web.RequestTrackingTelemetryModule, Microsoft.AI.Web">
+<Handlers>
+<!-- 
+        Add entries here to filter out additional handlers: 
+        
+        NOTE: handler configuration will be lost upon NuGet upgrade.
+        -->
+<Add>Microsoft.VisualStudio.Web.PageInspector.Runtime.Tracing.RequestDataHttpHandler</Add>
+<Add>System.Web.StaticFileHandler</Add>
+<Add>System.Web.Handlers.AssemblyResourceLoader</Add>
+<Add>System.Web.Optimization.BundleHandler</Add>
+<Add>System.Web.Script.Services.ScriptHandlerFactory</Add>
+<Add>System.Web.Handlers.TraceHandler</Add>
+<Add>System.Web.Services.Discovery.DiscoveryRequestHandler</Add>
+<Add>System.Web.HttpDebugHandler</Add>
+</Handlers>
+</Add>
+<Add Type="Microsoft.ApplicationInsights.Web.ExceptionTrackingTelemetryModule, Microsoft.AI.Web"/>
+<Add Type="Microsoft.ApplicationInsights.Web.AspNetDiagnosticTelemetryModule, Microsoft.AI.Web"/>
+</TelemetryModules>
+<TelemetryProcessors>
+<Add Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryProcessor, Microsoft.AI.PerfCounterCollector"/>
+<Add Type="Microsoft.ApplicationInsights.Extensibility.AutocollectedMetricsExtractor, Microsoft.ApplicationInsights"/>
+<Add Type="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.AdaptiveSamplingTelemetryProcessor, Microsoft.AI.ServerTelemetryChannel">
+<MaxTelemetryItemsPerSecond>5</MaxTelemetryItemsPerSecond>
+<ExcludedTypes>Event</ExcludedTypes>
+</Add>
+<Add Type="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.AdaptiveSamplingTelemetryProcessor, Microsoft.AI.ServerTelemetryChannel">
+<MaxTelemetryItemsPerSecond>5</MaxTelemetryItemsPerSecond>
+<IncludedTypes>Event</IncludedTypes>
+</Add>
+</TelemetryProcessors>
+<TelemetryChannel Type="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.ServerTelemetryChannel, Microsoft.AI.ServerTelemetryChannel"/>
+<!-- 
+    Learn more about Application Insights configuration with ApplicationInsights.config here: 
+    http://go.microsoft.com/fwlink/?LinkID=513840
+    
+    Note: If not present, please add <InstrumentationKey>Your Key</InstrumentationKey> to the top of this file.
+  --></ApplicationInsights>

--- a/ExcelBot/Constants/Constants.cs
+++ b/ExcelBot/Constants/Constants.cs
@@ -3,11 +3,7 @@
  * See LICENSE in the project root for license information.
  */
 
-using System;
-using System.Collections.Generic;
 using System.Configuration;
-using System.Linq;
-using System.Web;
 
 namespace ExcelBot
 {

--- a/ExcelBot/Controllers/ChartController.cs
+++ b/ExcelBot/Controllers/ChartController.cs
@@ -3,21 +3,16 @@
  * See LICENSE in the project root for license information.
  */
 
+using ExcelBot.Helpers;
+using ExcelBot.Model;
+using Microsoft.Bot.Connector;
 using System;
-using System.Collections.Generic;
-using System.Configuration;
-using System.Linq;
+using System.IO;
 using System.Net;
 using System.Net.Http;
-using System.Web;
-using System.Web.Http;
-using System.Threading.Tasks;
-using System.IO;
 using System.Net.Http.Headers;
-
-using ExcelBot.Helpers;
-using Microsoft.Bot.Connector;
-using ExcelBot.Model;
+using System.Threading.Tasks;
+using System.Web.Http;
 
 namespace ExcelBot
 {

--- a/ExcelBot/Controllers/ChartController.cs
+++ b/ExcelBot/Controllers/ChartController.cs
@@ -42,11 +42,11 @@ namespace ExcelBot
                     throw new ArgumentException("User nounce not found");
                 }
 
-                AuthBot.Models.AuthResult authResult = null;
+                BotAuth.Models.AuthResult authResult = null;
                 try
                 {
                     var userData = stateClient.BotState.GetUserData(channelId, userId);
-                    authResult = userData.GetProperty<AuthBot.Models.AuthResult>(AuthBot.ContextConstants.AuthResultKey);
+                    authResult = userData.GetProperty<BotAuth.Models.AuthResult>(BotAuth.ContextConstants.AuthResultKey);
                 }
                 catch
                 {

--- a/ExcelBot/Controllers/MessagesController.cs
+++ b/ExcelBot/Controllers/MessagesController.cs
@@ -3,19 +3,15 @@
  * See LICENSE in the project root for license information.
  */
 
+using ExcelBot.Dialogs;
+using ExcelBot.Helpers;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Connector;
 using System;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Web.Http;
-
-using Microsoft.Bot.Builder.Dialogs;
-using Microsoft.Bot.Connector;
-
-using ExcelBot.Dialogs;
-using ExcelBot.Helpers;
-using System.Web;
 
 namespace ExcelBot
 {

--- a/ExcelBot/Dialogs/CellsDialog.cs
+++ b/ExcelBot/Dialogs/CellsDialog.cs
@@ -3,18 +3,13 @@
  * See LICENSE in the project root for license information.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Web;
-using System.Threading.Tasks;
-
+using ExcelBot.Helpers;
+using ExcelBot.Model;
+using ExcelBot.Workers;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Luis.Models;
-
-using ExcelBot.Helpers;
-using ExcelBot.Workers;
-using ExcelBot.Model;
+using System;
+using System.Threading.Tasks;
 
 namespace ExcelBot.Dialogs
 {

--- a/ExcelBot/Dialogs/ChartsDialog.cs
+++ b/ExcelBot/Dialogs/ChartsDialog.cs
@@ -3,18 +3,12 @@
  * See LICENSE in the project root for license information.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Web;
-using System.Threading.Tasks;
-using System.Text;
-
-using Microsoft.Bot.Builder.Dialogs;
-using Microsoft.Bot.Builder.Luis.Models;
-
 using ExcelBot.Helpers;
 using ExcelBot.Workers;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Builder.Luis.Models;
+using System;
+using System.Threading.Tasks;
 
 namespace ExcelBot.Dialogs
 {

--- a/ExcelBot/Dialogs/DialogExtensions.cs
+++ b/ExcelBot/Dialogs/DialogExtensions.cs
@@ -3,17 +3,10 @@
  * See LICENSE in the project root for license information.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-using Autofac;
-
 using Microsoft.Bot.Builder.Dialogs;
-using Microsoft.Bot.Builder.Dialogs.Internals;
 using Microsoft.Bot.Builder.Luis.Models;
-using Microsoft.Bot.Connector;
+using System;
+using System.Threading.Tasks;
 
 namespace ExcelBot.Dialogs
 {

--- a/ExcelBot/Dialogs/ExcelBotDialog.cs
+++ b/ExcelBot/Dialogs/ExcelBotDialog.cs
@@ -3,23 +3,12 @@
  * See LICENSE in the project root for license information.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Web;
-using System.Threading.Tasks;
-using System.Text;
-using System.Configuration;
-
+using ExcelBot.Helpers;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Luis;
 using Microsoft.Bot.Builder.Luis.Models;
-
-using AuthBot;
-using AuthBot.Dialogs;
-using AuthBot.Models;
-
-using ExcelBot.Helpers;
+using System;
+using System.Threading.Tasks;
 
 namespace ExcelBot.Dialogs
 {

--- a/ExcelBot/Dialogs/GraphDialog.cs
+++ b/ExcelBot/Dialogs/GraphDialog.cs
@@ -3,19 +3,15 @@
  * See LICENSE in the project root for license information.
  */
 
-using System;
-using System.Threading;
-using System.Threading.Tasks;
-using System.Configuration;
-
 using AuthBot;
 using AuthBot.Dialogs;
-using AuthBot.Models;
-
+using ExcelBot.Helpers;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Connector;
-using ExcelBot.Helpers;
-using Microsoft.Bot.Builder.FormFlow;
+using System;
+using System.Configuration;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace ExcelBot.Dialogs
 {

--- a/ExcelBot/Dialogs/GraphDialog.cs
+++ b/ExcelBot/Dialogs/GraphDialog.cs
@@ -72,8 +72,8 @@ namespace ExcelBot.Dialogs
         private async Task ResumeAfterAuth(IDialogContext context, IAwaitable<AuthResult> result)
         {
             var message = await result;
-
-            await context.PostAsync("");
+            
+            await context.PostAsync("Now that you're logged in, what can I do for you?");
             context.Wait(MessageReceived);
         }
     }

--- a/ExcelBot/Dialogs/GraphDialog.cs
+++ b/ExcelBot/Dialogs/GraphDialog.cs
@@ -3,8 +3,10 @@
  * See LICENSE in the project root for license information.
  */
 
-using AuthBot;
-using AuthBot.Dialogs;
+using BotAuth;
+using BotAuth.AADv2;
+using BotAuth.Dialogs;
+using BotAuth.Models;
 using ExcelBot.Helpers;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Connector;
@@ -18,6 +20,15 @@ namespace ExcelBot.Dialogs
     [Serializable]
     public class GraphDialog : LuisDialog<object>
     {
+        protected static AuthenticationOptions authOptions = new AuthenticationOptions()
+        {
+            Authority = ConfigurationManager.AppSettings["ActiveDirectory.EndpointUrl"],
+            ClientId = ConfigurationManager.AppSettings["ActiveDirectory.ClientId"],
+            ClientSecret = ConfigurationManager.AppSettings["ActiveDirectory.ClientSecret"],
+            Scopes = new string[] { "User.Read", "Files.ReadWrite" },
+            RedirectUrl = ConfigurationManager.AppSettings["ActiveDirectory.RedirectUrl"],
+        };
+
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
         public override async Task StartAsync(IDialogContext context)
 #pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
@@ -29,18 +40,18 @@ namespace ExcelBot.Dialogs
         {
             var message = await item;
 
-            // Get access token to see if user is authenticated
-            ServicesHelper.AccessToken = await context.GetAccessToken(ConfigurationManager.AppSettings["ActiveDirectory.ResourceId"]);
-
+            // Try to get token silently
+            ServicesHelper.AccessToken = await GetAccessToken(context);
+            
             if (string.IsNullOrEmpty(ServicesHelper.AccessToken))
             {
-                // Start authentication dialog
-                await context.Forward(new AzureAuthDialog(ConfigurationManager.AppSettings["ActiveDirectory.ResourceId"]), this.ResumeAfterAuth, message, CancellationToken.None);
+                // Do prompt
+                await context.Forward(new AuthDialog(new MSALAuthProvider(), authOptions),
+                    ResumeAfterAuth, message, CancellationToken.None);
             }
             else if (message.Text == "logout")
             {
-                // Process logout message
-                await context.Logout();
+                await new MSALAuthProvider().Logout(authOptions, context);
                 context.Wait(this.MessageReceived);
             }
             else
@@ -50,12 +61,21 @@ namespace ExcelBot.Dialogs
             }
         }
 
-        private async Task ResumeAfterAuth(IDialogContext context, IAwaitable<string> result)
+        protected async Task<string> GetAccessToken(IDialogContext context)
+        {
+            var provider = new MSALAuthProvider();
+            var authResult = await provider.GetAccessToken(authOptions, context);
+
+            return (authResult == null ? string.Empty : authResult.AccessToken);
+        }
+
+        private async Task ResumeAfterAuth(IDialogContext context, IAwaitable<AuthResult> result)
         {
             var message = await result;
 
-            await context.PostAsync(message);
+            await context.PostAsync("");
             context.Wait(MessageReceived);
         }
     }
 }
+ 

--- a/ExcelBot/Dialogs/NamedItemsDialog.cs
+++ b/ExcelBot/Dialogs/NamedItemsDialog.cs
@@ -3,18 +3,13 @@
  * See LICENSE in the project root for license information.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Web;
-using System.Threading.Tasks;
-
+using ExcelBot.Helpers;
+using ExcelBot.Model;
+using ExcelBot.Workers;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Luis.Models;
-
-using ExcelBot.Helpers;
-using ExcelBot.Workers;
-using ExcelBot.Model;
+using System;
+using System.Threading.Tasks;
 
 namespace ExcelBot.Dialogs
 {

--- a/ExcelBot/Dialogs/OpenWorkbookDialog.cs
+++ b/ExcelBot/Dialogs/OpenWorkbookDialog.cs
@@ -3,21 +3,15 @@
  * See LICENSE in the project root for license information.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using System.Web;
-
-using Microsoft.Bot.Builder.Dialogs;
-using Microsoft.Bot.Builder.FormFlow;
-
 using AuthBot;
-
 using ExcelBot.Forms;
 using ExcelBot.Helpers;
 using ExcelBot.Workers;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Builder.FormFlow;
+using System;
 using System.Configuration;
+using System.Threading.Tasks;
 
 namespace ExcelBot.Dialogs
 {

--- a/ExcelBot/Dialogs/OpenWorkbookDialog.cs
+++ b/ExcelBot/Dialogs/OpenWorkbookDialog.cs
@@ -3,23 +3,21 @@
  * See LICENSE in the project root for license information.
  */
 
-using AuthBot;
 using ExcelBot.Forms;
 using ExcelBot.Helpers;
 using ExcelBot.Workers;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.FormFlow;
 using System;
-using System.Configuration;
 using System.Threading.Tasks;
 
 namespace ExcelBot.Dialogs
 {
     [Serializable]
-    public class ConfirmOpenWorkbookDialog : IDialog<bool>
+    public class ConfirmOpenWorkbookDialog : GraphDialog, IDialog<bool>
     {
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
-        public async Task StartAsync(IDialogContext context)
+        public override async Task StartAsync(IDialogContext context)
 #pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
         {
             PromptDialog.Confirm(context, AfterConfirming_OpenWorkbook, $"I don't have a workbook open. Do you want me to open a workbook?");
@@ -55,7 +53,7 @@ namespace ExcelBot.Dialogs
             if (form != null)
             {
                 // Get access token to see if user is authenticated
-                ServicesHelper.AccessToken = await context.GetAccessToken(ConfigurationManager.AppSettings["ActiveDirectory.ResourceId"]);
+                ServicesHelper.AccessToken = await GetAccessToken(context);
 
                 // Open the workbook
                 await WorkbookWorker.DoOpenWorkbookAsync(context, form.WorkbookName);

--- a/ExcelBot/Dialogs/TablesDialog.cs
+++ b/ExcelBot/Dialogs/TablesDialog.cs
@@ -3,18 +3,13 @@
  * See LICENSE in the project root for license information.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Web;
-using System.Threading.Tasks;
-
+using ExcelBot.Helpers;
+using ExcelBot.Model;
+using ExcelBot.Workers;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Luis.Models;
-
-using ExcelBot.Helpers;
-using ExcelBot.Workers;
-using ExcelBot.Model;
+using System;
+using System.Threading.Tasks;
 
 namespace ExcelBot.Dialogs
 {

--- a/ExcelBot/Dialogs/WorkbooksDialog.cs
+++ b/ExcelBot/Dialogs/WorkbooksDialog.cs
@@ -3,23 +3,16 @@
  * See LICENSE in the project root for license information.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Web;
-using System.Threading.Tasks;
-using System.Text;
-using System.Configuration;
-
-using Microsoft.Bot.Builder.Dialogs;
-using Microsoft.Bot.Builder.Luis.Models;
-using Microsoft.Bot.Builder.FormFlow;
-
 using AuthBot;
-
-using ExcelBot.Helpers;
 using ExcelBot.Forms;
+using ExcelBot.Helpers;
 using ExcelBot.Workers;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Builder.FormFlow;
+using Microsoft.Bot.Builder.Luis.Models;
+using System;
+using System.Configuration;
+using System.Threading.Tasks;
 
 namespace ExcelBot.Dialogs
 {

--- a/ExcelBot/Dialogs/WorkbooksDialog.cs
+++ b/ExcelBot/Dialogs/WorkbooksDialog.cs
@@ -3,7 +3,6 @@
  * See LICENSE in the project root for license information.
  */
 
-using AuthBot;
 using ExcelBot.Forms;
 using ExcelBot.Helpers;
 using ExcelBot.Workers;
@@ -11,7 +10,6 @@ using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.FormFlow;
 using Microsoft.Bot.Builder.Luis.Models;
 using System;
-using System.Configuration;
 using System.Threading.Tasks;
 
 namespace ExcelBot.Dialogs
@@ -53,7 +51,7 @@ namespace ExcelBot.Dialogs
             if (form != null)
             {
                 // Get access token to see if user is authenticated
-                ServicesHelper.AccessToken = await context.GetAccessToken(ConfigurationManager.AppSettings["ActiveDirectory.ResourceId"]);
+                ServicesHelper.AccessToken = await GetAccessToken(context);
 
                 // Open workbook 
                 await WorkbookWorker.DoOpenWorkbookAsync(context, form.WorkbookName);

--- a/ExcelBot/Dialogs/WorksheetsDialog.cs
+++ b/ExcelBot/Dialogs/WorksheetsDialog.cs
@@ -3,23 +3,16 @@
  * See LICENSE in the project root for license information.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Web;
-using System.Threading.Tasks;
-using System.Text;
-using System.Configuration;
-
-using Microsoft.Bot.Builder.Dialogs;
-using Microsoft.Bot.Builder.Luis.Models;
-using Microsoft.Bot.Builder.FormFlow;
-
 using AuthBot;
-
-using ExcelBot.Helpers;
 using ExcelBot.Forms;
+using ExcelBot.Helpers;
 using ExcelBot.Workers;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Builder.FormFlow;
+using Microsoft.Bot.Builder.Luis.Models;
+using System;
+using System.Configuration;
+using System.Threading.Tasks;
 
 namespace ExcelBot.Dialogs
 {

--- a/ExcelBot/Dialogs/WorksheetsDialog.cs
+++ b/ExcelBot/Dialogs/WorksheetsDialog.cs
@@ -3,7 +3,6 @@
  * See LICENSE in the project root for license information.
  */
 
-using AuthBot;
 using ExcelBot.Forms;
 using ExcelBot.Helpers;
 using ExcelBot.Workers;
@@ -11,7 +10,6 @@ using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.FormFlow;
 using Microsoft.Bot.Builder.Luis.Models;
 using System;
-using System.Configuration;
 using System.Threading.Tasks;
 
 namespace ExcelBot.Dialogs
@@ -91,7 +89,7 @@ namespace ExcelBot.Dialogs
             if (await result)
             {
                 // Get access token to see if user is authenticated
-                ServicesHelper.AccessToken = await context.GetAccessToken(ConfigurationManager.AppSettings["ActiveDirectory.ResourceId"]);
+                ServicesHelper.AccessToken = await GetAccessToken(context);
 
                 string workbookId = String.Empty;
                 context.UserData.TryGetValue<string>("WorkbookId", out workbookId);
@@ -120,7 +118,7 @@ namespace ExcelBot.Dialogs
             if (form != null)
             {
                 // Get access token to see if user is authenticated
-                ServicesHelper.AccessToken = await context.GetAccessToken(ConfigurationManager.AppSettings["ActiveDirectory.ResourceId"]);
+                ServicesHelper.AccessToken = await GetAccessToken(context);
 
                 // Select worksheet
                 await WorksheetWorker.DoSelectWorksheetAsync(context, form.WorksheetName);

--- a/ExcelBot/ExcelBot.csproj
+++ b/ExcelBot/ExcelBot.csproj
@@ -46,41 +46,41 @@
     <Reference Include="AuthBot, Version=3.6.5.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\AuthBot.3.6.5-alpha\lib\net40\AuthBot.dll</HintPath>
     </Reference>
-    <Reference Include="Autofac, Version=4.6.1.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\packages\Autofac.4.6.1\lib\net45\Autofac.dll</HintPath>
+    <Reference Include="Autofac, Version=4.6.2.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\packages\Autofac.4.6.2\lib\net45\Autofac.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AI.Agent.Intercept, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.ApplicationInsights.Agent.Intercept.2.4.0\lib\net45\Microsoft.AI.Agent.Intercept.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AI.DependencyCollector, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.ApplicationInsights.DependencyCollector.2.4.0\lib\net45\Microsoft.AI.DependencyCollector.dll</HintPath>
+    <Reference Include="Microsoft.AI.DependencyCollector, Version=2.5.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.ApplicationInsights.DependencyCollector.2.5.1\lib\net45\Microsoft.AI.DependencyCollector.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AI.PerfCounterCollector, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.ApplicationInsights.PerfCounterCollector.2.4.0\lib\net45\Microsoft.AI.PerfCounterCollector.dll</HintPath>
+    <Reference Include="Microsoft.AI.PerfCounterCollector, Version=2.5.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.ApplicationInsights.PerfCounterCollector.2.5.1\lib\net45\Microsoft.AI.PerfCounterCollector.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AI.ServerTelemetryChannel, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.4.0\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
+    <Reference Include="Microsoft.AI.ServerTelemetryChannel, Version=2.5.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.5.1\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AI.Web, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.ApplicationInsights.Web.2.4.0\lib\net45\Microsoft.AI.Web.dll</HintPath>
+    <Reference Include="Microsoft.AI.Web, Version=2.5.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.ApplicationInsights.Web.2.5.1\lib\net45\Microsoft.AI.Web.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AI.WindowsServer, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.ApplicationInsights.WindowsServer.2.4.0\lib\net45\Microsoft.AI.WindowsServer.dll</HintPath>
+    <Reference Include="Microsoft.AI.WindowsServer, Version=2.5.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.ApplicationInsights.WindowsServer.2.5.1\lib\net45\Microsoft.AI.WindowsServer.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.ApplicationInsights.2.4.0\lib\net46\Microsoft.ApplicationInsights.dll</HintPath>
+    <Reference Include="Microsoft.ApplicationInsights, Version=2.5.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.ApplicationInsights.2.5.1\lib\net46\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.TelemetryCorrelation.1.0.0\lib\net45\Microsoft.AspNet.TelemetryCorrelation.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bot.Builder, Version=3.9.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bot.Builder.3.9.1.0\lib\net46\Microsoft.Bot.Builder.dll</HintPath>
+    <Reference Include="Microsoft.Bot.Builder, Version=3.14.1.1, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bot.Builder.3.14.1.1\lib\net46\Microsoft.Bot.Builder.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bot.Builder.Autofac, Version=3.9.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bot.Builder.3.9.1.0\lib\net46\Microsoft.Bot.Builder.Autofac.dll</HintPath>
+    <Reference Include="Microsoft.Bot.Builder.Autofac, Version=3.14.1.1, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bot.Builder.3.14.1.1\lib\net46\Microsoft.Bot.Builder.Autofac.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bot.Connector, Version=3.9.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bot.Builder.3.9.1.0\lib\net46\Microsoft.Bot.Connector.dll</HintPath>
+    <Reference Include="Microsoft.Bot.Connector, Version=3.14.1.1, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bot.Connector.3.14.1.1\lib\net46\Microsoft.Bot.Connector.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Identity.Client, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -91,69 +91,74 @@
       <HintPath>..\packages\Microsoft.Identity.Client.1.0.304142221-alpha\lib\net45\Microsoft.Identity.Client.Platform.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=3.13.9.1126, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.3.13.9\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=3.19.2.6005, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.3.19.2\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory.Platform, Version=3.13.9.1126, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.3.13.9\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.Platform.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory.Platform, Version=3.19.2.6005, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.3.19.2\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.Platform.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.IdentityModel.Logging, Version=1.1.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Logging.1.1.3\lib\net451\Microsoft.IdentityModel.Logging.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.Logging, Version=5.2.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Logging.5.2.1\lib\net451\Microsoft.IdentityModel.Logging.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.IdentityModel.Protocol.Extensions, Version=1.0.40306.1554, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.IdentityModel.Protocol.Extensions.1.0.4.403061554\lib\net45\Microsoft.IdentityModel.Protocol.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.IdentityModel.Tokens, Version=5.1.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Tokens.5.1.3\lib\net451\Microsoft.IdentityModel.Tokens.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.Protocols, Version=5.2.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Protocols.5.2.1\lib\net451\Microsoft.IdentityModel.Protocols.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect, Version=5.2.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Protocols.OpenIdConnect.5.2.1\lib\net451\Microsoft.IdentityModel.Protocols.OpenIdConnect.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Tokens, Version=5.2.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Tokens.5.2.1\lib\net451\Microsoft.IdentityModel.Tokens.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Rest.ClientRuntime, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Rest.ClientRuntime.2.3.7\lib\net452\Microsoft.Rest.ClientRuntime.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Rest.ClientRuntime.2.3.11\lib\net452\Microsoft.Rest.ClientRuntime.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Win32.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Win32.Primitives.4.0.1\lib\net46\Microsoft.Win32.Primitives.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Win32.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Win32.Primitives.4.3.0\lib\net46\Microsoft.Win32.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.3.2.3\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.4.1\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
-    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=4.0.40306.1554, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.4.0.4.403061554\lib\net45\System.IdentityModel.Tokens.Jwt.dll</HintPath>
+    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=5.2.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.5.2.1\lib\net451\System.IdentityModel.Tokens.Jwt.dll</HintPath>
     </Reference>
+    <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Net" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Net.Http, Version=4.1.1.2, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.Http.4.3.3\lib\net46\System.Net.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.4\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Numerics" />
     <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.Runtime.Serialization.Primitives, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.Serialization.Primitives.4.1.1\lib\net46\System.Runtime.Serialization.Primitives.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Runtime.Serialization.Primitives, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.Serialization.Primitives.4.3.0\lib\net46\System.Runtime.Serialization.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="System.Security.Cryptography.Algorithms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.2.0\lib\net46\System.Security.Cryptography.Algorithms.dll</HintPath>
+      <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.3.1\lib\net46\System.Security.Cryptography.Algorithms.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Cryptography.Encoding.4.0.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
     </Reference>
-    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Cryptography.Primitives.4.0.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.1.0\lib\net46\System.Security.Cryptography.X509Certificates.dll</HintPath>
+      <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.2\lib\net46\System.Security.Cryptography.X509Certificates.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.DynamicData" />
@@ -165,19 +170,20 @@
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Web" />
-    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Web.Http, Version=5.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.4\lib\net45\System.Web.Http.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.Http.WebHost, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.WebHost.5.2.3\lib\net45\System.Web.Http.WebHost.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Web.Http.WebHost, Version=5.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.WebHost.5.2.4\lib\net45\System.Web.Http.WebHost.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Web.Services" />
     <Reference Include="System.EnterpriseServices" />
     <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Xml.ReaderWriter, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Xml.ReaderWriter.4.3.1\lib\net46\System.Xml.ReaderWriter.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Content Include="default.htm" />
@@ -224,7 +230,9 @@
     <Compile Include="Workers\WorkbookWorker.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="packages.config" />
+    <Content Include="packages.config">
+      <SubType>Designer</SubType>
+    </Content>
     <Content Include="ApplicationInsights.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/ExcelBot/ExcelBot.csproj
+++ b/ExcelBot/ExcelBot.csproj
@@ -245,6 +245,7 @@
     <None Include="Web.Release.config">
       <DependentUpon>Web.config</DependentUpon>
     </None>
+    <Content Include="PrivateSettings.config" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\uwp-csharp-excel-snippets-rest-sample\src\ExcelRESTService.Portable\ExcelRESTService.Portable.csproj">

--- a/ExcelBot/ExcelBot.csproj
+++ b/ExcelBot/ExcelBot.csproj
@@ -43,11 +43,14 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AuthBot, Version=3.6.5.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\AuthBot.3.6.5-alpha\lib\net40\AuthBot.dll</HintPath>
-    </Reference>
     <Reference Include="Autofac, Version=4.6.2.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
       <HintPath>..\packages\Autofac.4.6.2\lib\net45\Autofac.dll</HintPath>
+    </Reference>
+    <Reference Include="BotAuth, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\BotAuth.3.11.0-alpha\lib\net46\BotAuth.dll</HintPath>
+    </Reference>
+    <Reference Include="BotAuth.AADv2, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\BotAuth.AADv2.3.11.0-alpha\lib\net46\BotAuth.AADv2.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AI.Agent.Intercept, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.ApplicationInsights.Agent.Intercept.2.4.0\lib\net45\Microsoft.AI.Agent.Intercept.dll</HintPath>
@@ -83,19 +86,8 @@
       <HintPath>..\packages\Microsoft.Bot.Connector.3.14.1.1\lib\net46\Microsoft.Bot.Connector.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.Identity.Client, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Identity.Client.1.0.304142221-alpha\lib\net45\Microsoft.Identity.Client.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Identity.Client.Platform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Identity.Client.1.0.304142221-alpha\lib\net45\Microsoft.Identity.Client.Platform.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=3.19.2.6005, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.3.19.2\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory.Platform, Version=3.19.2.6005, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.3.19.2\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.Platform.dll</HintPath>
+    <Reference Include="Microsoft.Identity.Client, Version=1.1.0.0, Culture=neutral, PublicKeyToken=0a613f4dd989e8ae, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Identity.Client.1.1.0-preview\lib\net45\Microsoft.Identity.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.IdentityModel.Logging, Version=5.2.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.IdentityModel.Logging.5.2.1\lib\net451\Microsoft.IdentityModel.Logging.dll</HintPath>

--- a/ExcelBot/ExcelBot.csproj.user
+++ b/ExcelBot/ExcelBot.csproj.user
@@ -5,6 +5,12 @@
     <NameOfLastUsedPublishProfile>excelbotv3-staging - Web Deploy</NameOfLastUsedPublishProfile>
     <ProjectView>ProjectFiles</ProjectView>
     <LastActiveSolutionConfig>Debug|Any CPU</LastActiveSolutionConfig>
+    <Use64BitIISExpress />
+    <IISExpressSSLPort />
+    <IISExpressAnonymousAuthentication />
+    <IISExpressWindowsAuthentication />
+    <IISExpressUseClassicPipelineMode />
+    <UseGlobalApplicationHostFile />
   </PropertyGroup>
   <ProjectExtensions>
     <VisualStudio>

--- a/ExcelBot/Forms/OpenWorkbookForm.cs
+++ b/ExcelBot/Forms/OpenWorkbookForm.cs
@@ -3,12 +3,8 @@
  * See LICENSE in the project root for license information.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Web;
-
 using Microsoft.Bot.Builder.FormFlow;
+using System;
 
 namespace ExcelBot.Forms
 {

--- a/ExcelBot/Forms/SelectWorksheetForm.cs
+++ b/ExcelBot/Forms/SelectWorksheetForm.cs
@@ -3,13 +3,9 @@
  * See LICENSE in the project root for license information.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Web;
-
 using Microsoft.Bot.Builder.FormFlow;
 using Microsoft.Bot.Builder.FormFlow.Advanced;
+using System;
 
 namespace ExcelBot.Forms
 {

--- a/ExcelBot/Global.asax.cs
+++ b/ExcelBot/Global.asax.cs
@@ -13,13 +13,6 @@ namespace ExcelBot
         protected void Application_Start()
         {
             GlobalConfiguration.Configure(WebApiConfig.Register);
-
-            AuthBot.Models.AuthSettings.Mode = ConfigurationManager.AppSettings["ActiveDirectory.Mode"];
-            AuthBot.Models.AuthSettings.EndpointUrl = ConfigurationManager.AppSettings["ActiveDirectory.EndpointUrl"];
-            AuthBot.Models.AuthSettings.Tenant = ConfigurationManager.AppSettings["ActiveDirectory.Tenant"];
-            AuthBot.Models.AuthSettings.RedirectUrl = ConfigurationManager.AppSettings["ActiveDirectory.RedirectUrl"];
-            AuthBot.Models.AuthSettings.ClientId = ConfigurationManager.AppSettings["ActiveDirectory.ClientId"];
-            AuthBot.Models.AuthSettings.ClientSecret = ConfigurationManager.AppSettings["ActiveDirectory.ClientSecret"];
         }
     }
 }

--- a/ExcelBot/Global.asax.cs
+++ b/ExcelBot/Global.asax.cs
@@ -3,13 +3,8 @@
  * See LICENSE in the project root for license information.
  */
 
-using System;
-using System.Collections.Generic;
 using System.Configuration;
-using System.Linq;
-using System.Web;
 using System.Web.Http;
-using System.Web.Routing;
 
 namespace ExcelBot
 {

--- a/ExcelBot/Helpers/ExcelHelper.cs
+++ b/ExcelBot/Helpers/ExcelHelper.cs
@@ -3,15 +3,10 @@
  * See LICENSE in the project root for license information.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Web;
-
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Connector;
+using System;
+using System.Threading.Tasks;
 
 namespace ExcelBot.Helpers
 {

--- a/ExcelBot/Helpers/IndexOf.cs
+++ b/ExcelBot/Helpers/IndexOf.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Web;
 
 namespace ExcelBot.Helpers
 {

--- a/ExcelBot/Helpers/LuisHelper.cs
+++ b/ExcelBot/Helpers/LuisHelper.cs
@@ -3,13 +3,11 @@
  * See LICENSE in the project root for license information.
  */
 
+using Microsoft.Bot.Builder.Luis.Models;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Web;
-
-using Microsoft.Bot.Builder.Luis.Models;
 
 namespace ExcelBot.Helpers
 {

--- a/ExcelBot/Helpers/RequestHelper.cs
+++ b/ExcelBot/Helpers/RequestHelper.cs
@@ -1,15 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using Microsoft.ApplicationInsights;
-
-using ExcelBot.Dialogs;
-using ExcelBot.Model;
-using System.Net.Http;
-using Newtonsoft.Json.Linq;
 
 /* 
  * Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.

--- a/ExcelBot/Helpers/ServicesHelper.cs
+++ b/ExcelBot/Helpers/ServicesHelper.cs
@@ -3,18 +3,12 @@
  * See LICENSE in the project root for license information.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using System.Web;
-using System.Web.Http;
-
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Connector;
-
 using Office365Service;
 using Office365Service.ViewModel;
+using System.Threading.Tasks;
+using System.Web;
 
 namespace ExcelBot.Helpers
 {

--- a/ExcelBot/Helpers/TelemetryHelper.cs
+++ b/ExcelBot/Helpers/TelemetryHelper.cs
@@ -3,18 +3,13 @@
  * See LICENSE in the project root for license information.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Web;
-
 using Microsoft.ApplicationInsights;
-
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Luis.Models;
 using Microsoft.Bot.Connector;
+using System.Collections.Generic;
+using System.Text;
+using System.Web;
 
 namespace ExcelBot.Helpers
 {

--- a/ExcelBot/Model/ChartAttachment.cs
+++ b/ExcelBot/Model/ChartAttachment.cs
@@ -3,11 +3,6 @@
  * See LICENSE in the project root for license information.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Web;
-
 namespace ExcelBot.Model
 {
     public class ChartAttachment

--- a/ExcelBot/Model/ObjectType.cs
+++ b/ExcelBot/Model/ObjectType.cs
@@ -3,11 +3,6 @@
  * See LICENSE in the project root for license information.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Web;
-
 namespace ExcelBot.Model
 {
     public enum ObjectType

--- a/ExcelBot/Model/UserData.cs
+++ b/ExcelBot/Model/UserData.cs
@@ -3,11 +3,6 @@
  * See LICENSE in the project root for license information.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Web;
-
 namespace ExcelBot.Model
 {
     public class UserData

--- a/ExcelBot/PrivateSettings.config.example
+++ b/ExcelBot/PrivateSettings.config.example
@@ -5,5 +5,5 @@
   <!-- update these with your app ID registration information -->
   <add key="ActiveDirectory.ClientId" value="AD CLIENT ID" />
   <add key="ActiveDirectory.ClientSecret" value="AD CLIENT SECRET" />
-  <add key="ActiveDirectory.RedirectUrl" value="https://BOT HOST NAME/api/OAuthCallback" />
+  <add key="ActiveDirectory.RedirectUrl" value="https://BOT HOST NAME/callback" />
 </appSettings>

--- a/ExcelBot/PrivateSettings.config.example
+++ b/ExcelBot/PrivateSettings.config.example
@@ -1,0 +1,9 @@
+﻿<appSettings>
+  <!-- update these with your BotId, Microsoft App Id and your Microsoft App Password-->
+  <add key="MicrosoftAppId" value="BOT APP ID" />
+  <add key="MicrosoftAppPassword" value="BOT APP PASSWORD" />
+  <!-- update these with your app ID registration information -->
+  <add key="ActiveDirectory.ClientId" value="AD CLIENT ID" />
+  <add key="ActiveDirectory.ClientSecret" value="AD CLIENT SECRET" />
+  <add key="ActiveDirectory.RedirectUrl" value="https://BOT HOST NAME/api/OAuthCallback" />
+</appSettings>

--- a/ExcelBot/Web.config
+++ b/ExcelBot/Web.config
@@ -44,12 +44,7 @@
       </files>
     </defaultDocument>
     
-  <handlers>
-      <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
-      <remove name="OPTIONSVerbHandler" />
-      <remove name="TRACEVerbHandler" />
-      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
-    </handlers>
+  
   <validation validateIntegratedModeConfiguration="false" />
   <modules>
   <remove name="TelemetryCorrelationHttpModule" />
@@ -57,7 +52,12 @@
   <remove name="ApplicationInsightsWebTracking" />
   <add name="ApplicationInsightsWebTracking" type="Microsoft.ApplicationInsights.Web.ApplicationInsightsHttpModule, Microsoft.AI.Web" preCondition="managedHandler" />
   </modules>
-  </system.webServer>
+  <handlers>
+      <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
+      <remove name="OPTIONSVerbHandler" />
+      <remove name="TRACEVerbHandler" />
+      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+    </handlers></system.webServer>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
@@ -74,7 +74,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Net.Http.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
@@ -82,19 +82,19 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.4.0" newVersion="5.2.4.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Bot.Connector" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.9.1.0" newVersion="3.9.1.0" />
+        <bindingRedirect oldVersion="0.0.0.0-3.14.1.1" newVersion="3.14.1.1" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Autofac" publicKeyToken="17863af14b0044da" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.6.1.0" newVersion="4.6.1.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.30826.1200" newVersion="4.0.30826.1200" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.1.0" newVersion="5.2.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.IdentityModel.Protocol.Extensions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
@@ -106,15 +106,51 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Runtime.Serialization.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Bot.Builder" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.9.1.0" newVersion="3.9.1.0" />
+        <bindingRedirect oldVersion="0.0.0.0-3.14.1.1" newVersion="3.14.1.1" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Bot.Builder.Autofac" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.9.1.0" newVersion="3.9.1.0" />
+        <bindingRedirect oldVersion="0.0.0.0-3.14.1.1" newVersion="3.14.1.1" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.19.2.6005" newVersion="3.19.2.6005" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.4.0" newVersion="5.2.4.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.2" newVersion="4.1.1.2" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.1" newVersion="4.0.2.1" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Xml.ReaderWriter" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.1.0" newVersion="5.2.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.1.0" newVersion="5.2.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.1.0" newVersion="5.2.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.1.0" newVersion="5.2.1.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/ExcelBot/Web.config
+++ b/ExcelBot/Web.config
@@ -6,19 +6,12 @@
   http://go.microsoft.com/fwlink/?LinkId=301879
   -->
 <configuration>
-  <appSettings>
-    <!-- update these with your BotId, Microsoft App Id and your Microsoft App Password-->
-    <add key="MicrosoftAppId" value="BOT APP ID" />
-    <add key="MicrosoftAppPassword" value="BOT APP PASSWORD" />
-
+  <appSettings file="PrivateSettings.config">
     <!-- AAD Auth v1 settings -->
     <add key="ActiveDirectory.Mode" value="v1" />
     <add key="ActiveDirectory.ResourceId" value="https://graph.microsoft.com/" />
     <add key="ActiveDirectory.EndpointUrl" value="https://login.microsoftonline.com" />
     <add key="ActiveDirectory.Tenant" value="common" />
-    <add key="ActiveDirectory.ClientId" value="AD CLIENT ID" />
-    <add key="ActiveDirectory.ClientSecret" value="AD CLIENT SECRET" />
-    <add key="ActiveDirectory.RedirectUrl" value="https://BOT HOST NAME/api/OAuthCallback" />
   </appSettings>
   <!--
     For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.

--- a/ExcelBot/Workers/CellWorker.cs
+++ b/ExcelBot/Workers/CellWorker.cs
@@ -3,15 +3,10 @@
  * See LICENSE in the project root for license information.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using System.Web;
-
-using Microsoft.Bot.Builder.Dialogs;
-
 using ExcelBot.Helpers;
+using Microsoft.Bot.Builder.Dialogs;
+using System;
+using System.Threading.Tasks;
 
 namespace ExcelBot.Workers
 {

--- a/ExcelBot/Workers/ChartsWorker.cs
+++ b/ExcelBot/Workers/ChartsWorker.cs
@@ -3,20 +3,15 @@
  * See LICENSE in the project root for license information.
  */
 
+using ExcelBot.Helpers;
+using ExcelBot.Model;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Connector;
+using Microsoft.ExcelServices;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Web;
-
-using Microsoft.Bot.Builder.Dialogs;
-using Microsoft.Bot.Connector;
-
-using Microsoft.ExcelServices;
-
-using ExcelBot.Helpers;
-using ExcelBot.Model;
 
 namespace ExcelBot.Workers
 {

--- a/ExcelBot/Workers/NamedItemsWorker.cs
+++ b/ExcelBot/Workers/NamedItemsWorker.cs
@@ -3,19 +3,14 @@
  * See LICENSE in the project root for license information.
  */
 
+using ExcelBot.Helpers;
+using ExcelBot.Model;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.ExcelServices;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using System.Web;
-
-using Microsoft.Bot.Builder.Dialogs;
-
-using Microsoft.ExcelServices;
-
-using ExcelBot.Helpers;
-using ExcelBot.Model;
 
 namespace ExcelBot.Workers
 {

--- a/ExcelBot/Workers/TablesWorker.cs
+++ b/ExcelBot/Workers/TablesWorker.cs
@@ -3,18 +3,14 @@
  * See LICENSE in the project root for license information.
  */
 
+using ExcelBot.Helpers;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.ExcelServices;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using System.Web;
-
-using Microsoft.Bot.Builder.Dialogs;
-
-using Microsoft.ExcelServices;
-
-using ExcelBot.Helpers;
 
 namespace ExcelBot.Workers
 {

--- a/ExcelBot/Workers/WorkbookWorker.cs
+++ b/ExcelBot/Workers/WorkbookWorker.cs
@@ -3,15 +3,10 @@
  * See LICENSE in the project root for license information.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using System.Web;
-
-using Microsoft.Bot.Builder.Dialogs;
-
 using ExcelBot.Helpers;
+using Microsoft.Bot.Builder.Dialogs;
+using System;
+using System.Threading.Tasks;
 
 namespace ExcelBot.Workers
 {

--- a/ExcelBot/Workers/WorksheetWorker.cs
+++ b/ExcelBot/Workers/WorksheetWorker.cs
@@ -3,18 +3,13 @@
  * See LICENSE in the project root for license information.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using System.Web;
-using System.Text;
-
-using Microsoft.Bot.Builder.Dialogs;
-
-using Microsoft.ExcelServices;
-
 using ExcelBot.Helpers;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.ExcelServices;
+using System;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 
 namespace ExcelBot.Workers
 {

--- a/ExcelBot/packages.config
+++ b/ExcelBot/packages.config
@@ -3,57 +3,60 @@
 <!-- See LICENSE in the project root for license information -->
 <packages>
   <package id="AuthBot" version="3.6.5-alpha" targetFramework="net46" />
-  <package id="Autofac" version="4.6.1" targetFramework="net46" />
+  <package id="Autofac" version="4.6.2" targetFramework="net46" />
   <package id="AutoRest" version="0.17.3" targetFramework="net46" />
   <package id="Chronic.Signed" version="0.3.2" targetFramework="net46" />
-  <package id="Microsoft.ApplicationInsights" version="2.4.0" targetFramework="net46" />
+  <package id="Microsoft.ApplicationInsights" version="2.5.1" targetFramework="net46" />
   <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.4.0" targetFramework="net46" />
-  <package id="Microsoft.ApplicationInsights.DependencyCollector" version="2.4.0" targetFramework="net46" />
-  <package id="Microsoft.ApplicationInsights.PerfCounterCollector" version="2.4.0" targetFramework="net46" />
-  <package id="Microsoft.ApplicationInsights.Web" version="2.4.0" targetFramework="net46" />
-  <package id="Microsoft.ApplicationInsights.WindowsServer" version="2.4.0" targetFramework="net46" />
-  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.4.0" targetFramework="net46" />
+  <package id="Microsoft.ApplicationInsights.DependencyCollector" version="2.5.1" targetFramework="net46" />
+  <package id="Microsoft.ApplicationInsights.PerfCounterCollector" version="2.5.1" targetFramework="net46" />
+  <package id="Microsoft.ApplicationInsights.Web" version="2.5.1" targetFramework="net46" />
+  <package id="Microsoft.ApplicationInsights.WindowsServer" version="2.5.1" targetFramework="net46" />
+  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.5.1" targetFramework="net46" />
   <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net46" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net46" />
-  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net46" />
-  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder" version="3.9.1.0" targetFramework="net46" />
+  <package id="Microsoft.AspNet.WebApi" version="5.2.4" targetFramework="net46" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.4" targetFramework="net46" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.4" targetFramework="net46" />
+  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder" version="3.14.1.1" targetFramework="net46" />
+  <package id="Microsoft.Bot.Connector" version="3.14.1.1" targetFramework="net46" />
   <package id="Microsoft.Identity.Client" version="1.0.304142221-alpha" targetFramework="net46" />
-  <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="3.13.9" targetFramework="net46" />
-  <package id="Microsoft.IdentityModel.Logging" version="1.1.3" targetFramework="net46" />
+  <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="3.19.2" targetFramework="net46" />
+  <package id="Microsoft.IdentityModel.Logging" version="5.2.1" targetFramework="net46" />
   <package id="Microsoft.IdentityModel.Protocol.Extensions" version="1.0.4.403061554" targetFramework="net46" />
-  <package id="Microsoft.IdentityModel.Tokens" version="5.1.3" targetFramework="net46" />
-  <package id="Microsoft.Rest.ClientRuntime" version="2.3.7" targetFramework="net46" />
-  <package id="Microsoft.Win32.Primitives" version="4.0.1" targetFramework="net46" />
+  <package id="Microsoft.IdentityModel.Protocols" version="5.2.1" targetFramework="net46" />
+  <package id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="5.2.1" targetFramework="net46" />
+  <package id="Microsoft.IdentityModel.Tokens" version="5.2.1" targetFramework="net46" />
+  <package id="Microsoft.Rest.ClientRuntime" version="2.3.11" targetFramework="net46" />
+  <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net46" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.3" targetFramework="net46" />
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net46" />
-  <package id="System.Collections" version="4.0.11" targetFramework="net46" />
-  <package id="System.Collections.Concurrent" version="4.0.12" targetFramework="net46" />
-  <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net46" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net46" />
-  <package id="System.Globalization" version="4.0.11" targetFramework="net46" />
-  <package id="System.IdentityModel.Tokens.Jwt" version="4.0.4.403061554" targetFramework="net46" />
-  <package id="System.IO" version="4.1.0" targetFramework="net46" />
-  <package id="System.Linq" version="4.1.0" targetFramework="net46" />
-  <package id="System.Net.Http" version="4.0.0" targetFramework="net46" />
-  <package id="System.Net.Primitives" version="4.0.11" targetFramework="net46" />
-  <package id="System.Reflection" version="4.1.0" targetFramework="net46" />
-  <package id="System.Reflection.Extensions" version="4.0.1" targetFramework="net46" />
-  <package id="System.Runtime" version="4.1.0" targetFramework="net46" />
-  <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net46" />
-  <package id="System.Runtime.InteropServices" version="4.1.0" targetFramework="net46" />
-  <package id="System.Runtime.Serialization.Json" version="4.0.2" targetFramework="net46" />
-  <package id="System.Runtime.Serialization.Primitives" version="4.1.1" targetFramework="net46" />
-  <package id="System.Security.Cryptography.Algorithms" version="4.2.0" targetFramework="net46" />
-  <package id="System.Security.Cryptography.Encoding" version="4.0.0" targetFramework="net46" />
-  <package id="System.Security.Cryptography.Primitives" version="4.0.0" targetFramework="net46" />
-  <package id="System.Security.Cryptography.X509Certificates" version="4.1.0" targetFramework="net46" />
-  <package id="System.Text.Encoding" version="4.0.11" targetFramework="net46" />
-  <package id="System.Text.Encoding.Extensions" version="4.0.11" targetFramework="net46" />
-  <package id="System.Text.RegularExpressions" version="4.1.0" targetFramework="net46" />
-  <package id="System.Threading" version="4.0.11" targetFramework="net46" />
-  <package id="System.Threading.Tasks" version="4.0.11" targetFramework="net46" />
-  <package id="System.Xml.ReaderWriter" version="4.0.11" targetFramework="net46" />
-  <package id="System.Xml.XDocument" version="4.0.11" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net46" />
+  <package id="System.Collections" version="4.3.0" targetFramework="net46" />
+  <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net46" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net46" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.1" targetFramework="net46" />
+  <package id="System.Globalization" version="4.3.0" targetFramework="net46" />
+  <package id="System.IdentityModel.Tokens.Jwt" version="5.2.1" targetFramework="net46" />
+  <package id="System.IO" version="4.3.0" targetFramework="net46" />
+  <package id="System.Linq" version="4.3.0" targetFramework="net46" />
+  <package id="System.Net.Http" version="4.3.3" targetFramework="net46" />
+  <package id="System.Net.Primitives" version="4.3.0" targetFramework="net46" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="net46" />
+  <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net46" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net46" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net46" />
+  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net46" />
+  <package id="System.Runtime.Serialization.Json" version="4.3.0" targetFramework="net46" />
+  <package id="System.Runtime.Serialization.Primitives" version="4.3.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.1" targetFramework="net46" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.2" targetFramework="net46" />
+  <package id="System.Text.Encoding" version="4.3.0" targetFramework="net46" />
+  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net46" />
+  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net46" />
+  <package id="System.Threading" version="4.3.0" targetFramework="net46" />
+  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net46" />
+  <package id="System.Xml.ReaderWriter" version="4.3.1" targetFramework="net46" />
+  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net46" />
 </packages>

--- a/ExcelBot/packages.config
+++ b/ExcelBot/packages.config
@@ -2,9 +2,10 @@
 <!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. -->
 <!-- See LICENSE in the project root for license information -->
 <packages>
-  <package id="AuthBot" version="3.6.5-alpha" targetFramework="net46" />
   <package id="Autofac" version="4.6.2" targetFramework="net46" />
   <package id="AutoRest" version="0.17.3" targetFramework="net46" />
+  <package id="BotAuth" version="3.11.0-alpha" targetFramework="net46" />
+  <package id="BotAuth.AADv2" version="3.11.0-alpha" targetFramework="net46" />
   <package id="Chronic.Signed" version="0.3.2" targetFramework="net46" />
   <package id="Microsoft.ApplicationInsights" version="2.5.1" targetFramework="net46" />
   <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.4.0" targetFramework="net46" />
@@ -20,8 +21,7 @@
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.4" targetFramework="net46" />
   <package id="Microsoft.Bot.Builder" version="3.14.1.1" targetFramework="net46" />
   <package id="Microsoft.Bot.Connector" version="3.14.1.1" targetFramework="net46" />
-  <package id="Microsoft.Identity.Client" version="1.0.304142221-alpha" targetFramework="net46" />
-  <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="3.19.2" targetFramework="net46" />
+  <package id="Microsoft.Identity.Client" version="1.1.0-preview" targetFramework="net46" />
   <package id="Microsoft.IdentityModel.Logging" version="5.2.1" targetFramework="net46" />
   <package id="Microsoft.IdentityModel.Protocol.Extensions" version="1.0.4.403061554" targetFramework="net46" />
   <package id="Microsoft.IdentityModel.Protocols" version="5.2.1" targetFramework="net46" />

--- a/README.md
+++ b/README.md
@@ -18,13 +18,14 @@ Complete the these steps to setup your development environment to build and test
 
   * Clone this repo to a local folder
   * Clone and build the [Excel REST API Explorer](https://github.com/microsoftgraph/uwp-csharp-excel-snippets-rest-sample) sample to the same folder. Excel Bot uses a library in the Excel REST API Explorer project to make the REST API calls to the Microsoft Graph.
+  * Rename the **./ExcelBot/PrivateSettings.config.example** file to **PrivateSettings.config**.
   * Open the ExcelBot.sln solution file
   * Register the bot in the [Bot Framework](https://dev.botframework.com/bots/new)
-  * Copy the bot MicrosoftAppId and MicrosoftAppPassword to the Web.config file
+  * Copy the bot MicrosoftAppId and MicrosoftAppPassword to the PrivateSettings.config file
   * [Register the bot to call the Microsoft Graph](http://dev.office.com/app-registration)
     - Assign the following Delegated Permissions to the app: Sign in and read user profile (User.Read), Have full access to user files (Files.ReadWrite)
     - Add the bots host name to the list of Reply URLs using the format https://BOT HOST NAME
-  * Copy the Azure Active Directory Client Id and Secret to the Web.config file
+  * Copy the Azure Active Directory Client Id and Secret to the PrivateSettings.config file
   * Create a new model in the [LUIS](https://www.luis.ai) service
   * Import the LUIS\excelbot.json file into LUIS
   * Train and publish the LUIS model
@@ -35,7 +36,7 @@ Complete the these steps to setup your development environment to build and test
   * Press F5 to start the bot locally
   * Test the bot locally with the [Bot Framework Emulator](https://docs.botframework.com/en-us/tools/bot-framework-emulator)
   * Create a web app in Azure
-  * Replace the bots host name in the Web.config file
+  * Replace the bots host name in the PrivateSettings.config file
   * Publish the solution to the Azure web app
   * Test the deployed bot using the Web Chat control by browsing to the chat.htm page  
   

--- a/README.md
+++ b/README.md
@@ -22,9 +22,7 @@ Complete the these steps to setup your development environment to build and test
   * Open the ExcelBot.sln solution file
   * Register the bot in the [Bot Framework](https://dev.botframework.com/bots/new)
   * Copy the bot MicrosoftAppId and MicrosoftAppPassword to the PrivateSettings.config file
-  * [Register the bot to call the Microsoft Graph](http://dev.office.com/app-registration)
-    - Assign the following Delegated Permissions to the app: Sign in and read user profile (User.Read), Have full access to user files (Files.ReadWrite)
-    - Add the bots host name to the list of Reply URLs using the format https://BOT HOST NAME
+  * [Register the bot to call the Microsoft Graph](#register-bot-to-call-graph)
   * Copy the Azure Active Directory Client Id and Secret to the PrivateSettings.config file
   * Create a new model in the [LUIS](https://www.luis.ai) service
   * Import the LUIS\excelbot.json file into LUIS
@@ -39,7 +37,17 @@ Complete the these steps to setup your development environment to build and test
   * Replace the bots host name in the PrivateSettings.config file
   * Publish the solution to the Azure web app
   * Test the deployed bot using the Web Chat control by browsing to the chat.htm page  
-  
+
+### Register bot to call Graph
+
+Head over to the [Application Registration Portal](https://apps.dev.microsoft.com/) to quickly get an application ID and secret. 
+
+1. Using the **Sign in** link, sign in with either your Microsoft account (Outlook.com), or your work or school account (Office 365).
+1. Click the **Add an app** button. Enter a name and click **Create application**. 
+1. Locate the **Application Secrets** section, and click the **Generate New Password** button. Copy the password now and save it to a safe place. Once you've copied the password, click **Ok**.
+1. Locate the **Platforms** section, and click **Add Platform**. Choose **Web**, then enter `http://<BOT_HOST_NAME>/callback`, replacing `<BOT_HOST_NAME>` with the hostname for your bot under **Redirect URIs**.
+1. Click **Save** to complete the registration. Copy the **Application Id** and save it along with the password you copied earlier. We'll need those values soon.
+
 ## Give us your feedback
 
 Your feedback is important to us.  


### PR DESCRIPTION
I was asked to update this bot to use MSAL. However, the bot doesn't use an Azure auth client, instead it uses AuthBot.

AuthBot is now deprecated in favor of BotAuth, which has an AADv2 option, which under the covers uses MSAL. I updated the project to use BotAuth AADv2.