### PR TITLE
Added CosmosDB bot state store

### DIFF
--- a/ExcelBot/Controllers/ChartController.cs
+++ b/ExcelBot/Controllers/ChartController.cs
@@ -5,7 +5,6 @@
 
 using ExcelBot.Helpers;
 using ExcelBot.Model;
-using Microsoft.Bot.Connector;
 using System;
 using System.IO;
 using System.Net;
@@ -25,16 +24,13 @@ namespace ExcelBot
             RequestHelper.RequestUri = Request.RequestUri;
 
             // Get access token
-            var stateClient = (channelId == "emulator") ? 
-                                new StateClient(new Uri("http://localhost:21706"), new MicrosoftAppCredentials(Constants.microsoftAppId, Constants.microsoftAppPassword)) :
-                                new StateClient(new MicrosoftAppCredentials(Constants.microsoftAppId, Constants.microsoftAppPassword));
 
             // Get value of user nonce
             ChartAttachment chartAttachment = null;
 
             try
             {
-                var conversationData = stateClient.BotState.GetConversationData(channelId, conversationId);
+                var conversationData = await BotStateHelper.GetConversationDataAsync(channelId, conversationId);
                 chartAttachment = conversationData.GetProperty<ChartAttachment>(userNonce);
 
                 if (chartAttachment == null)
@@ -45,8 +41,8 @@ namespace ExcelBot
                 BotAuth.Models.AuthResult authResult = null;
                 try
                 {
-                    var userData = stateClient.BotState.GetUserData(channelId, userId);
-                    authResult = userData.GetProperty<BotAuth.Models.AuthResult>(BotAuth.ContextConstants.AuthResultKey);
+                    var userData = await BotStateHelper.GetUserDataAsync(channelId, userId);
+                    authResult = userData.GetProperty<BotAuth.Models.AuthResult>($"MSALAuthProvider{BotAuth.ContextConstants.AuthResultKey}");
                 }
                 catch
                 {

--- a/ExcelBot/ExcelBot.csproj
+++ b/ExcelBot/ExcelBot.csproj
@@ -46,11 +46,20 @@
     <Reference Include="Autofac, Version=4.6.2.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
       <HintPath>..\packages\Autofac.4.6.2\lib\net45\Autofac.dll</HintPath>
     </Reference>
+    <Reference Include="Autofac.Integration.WebApi, Version=3.0.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\packages\Autofac.WebApi.3.1.0\lib\net40\Autofac.Integration.WebApi.dll</HintPath>
+    </Reference>
     <Reference Include="BotAuth, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\BotAuth.3.11.0-alpha\lib\net46\BotAuth.dll</HintPath>
     </Reference>
     <Reference Include="BotAuth.AADv2, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\BotAuth.AADv2.3.11.0-alpha\lib\net46\BotAuth.AADv2.dll</HintPath>
+    </Reference>
+    <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AI.Agent.Intercept, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.ApplicationInsights.Agent.Intercept.2.4.0\lib\net45\Microsoft.AI.Agent.Intercept.dll</HintPath>
@@ -76,16 +85,37 @@
     <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.TelemetryCorrelation.1.0.0\lib\net45\Microsoft.AspNet.TelemetryCorrelation.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Azure.Documents.Client, Version=1.18.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.DocumentDB.1.18.0\lib\net45\Microsoft.Azure.Documents.Client.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.KeyVault.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Bot.Builder, Version=3.14.1.1, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Bot.Builder.3.14.1.1\lib\net46\Microsoft.Bot.Builder.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Bot.Builder.Autofac, Version=3.14.1.1, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Bot.Builder.3.14.1.1\lib\net46\Microsoft.Bot.Builder.Autofac.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Bot.Builder.Azure, Version=3.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bot.Builder.Azure.3.2.5\lib\net46\Microsoft.Bot.Builder.Azure.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Bot.Builder.History, Version=3.12.2.4, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bot.Builder.History.3.12.2.4\lib\net46\Microsoft.Bot.Builder.History.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Bot.Connector, Version=3.14.1.1, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Bot.Connector.3.14.1.1\lib\net46\Microsoft.Bot.Connector.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Data.Edm, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Data.Edm.5.6.4\lib\net40\Microsoft.Data.Edm.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.OData, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Data.OData.5.6.4\lib\net40\Microsoft.Data.OData.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Data.Services.Client.5.6.4\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Identity.Client, Version=1.1.0.0, Culture=neutral, PublicKeyToken=0a613f4dd989e8ae, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Identity.Client.1.1.0-preview\lib\net45\Microsoft.Identity.Client.dll</HintPath>
     </Reference>
@@ -113,6 +143,9 @@
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.3.2.3\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=7.2.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\WindowsAzure.Storage.7.2.1\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -152,6 +185,9 @@
     <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.2\lib\net46\System.Security.Cryptography.X509Certificates.dll</HintPath>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Spatial, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Spatial.5.6.4\lib\net40\System.Spatial.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
@@ -204,6 +240,7 @@
     <Compile Include="Global.asax.cs">
       <DependentUpon>Global.asax</DependentUpon>
     </Compile>
+    <Compile Include="Helpers\BotStateHelper.cs" />
     <Compile Include="Helpers\IndexOf.cs" />
     <Compile Include="Helpers\RequestHelper.cs" />
     <Compile Include="Helpers\ServicesHelper.cs" />
@@ -273,6 +310,13 @@
       </FlavorProperties>
     </VisualStudio>
   </ProjectExtensions>
+  <Import Project="..\packages\Microsoft.Azure.DocumentDB.1.18.0\build\Microsoft.Azure.DocumentDB.targets" Condition="Exists('..\packages\Microsoft.Azure.DocumentDB.1.18.0\build\Microsoft.Azure.DocumentDB.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.Azure.DocumentDB.1.18.0\build\Microsoft.Azure.DocumentDB.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Azure.DocumentDB.1.18.0\build\Microsoft.Azure.DocumentDB.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/ExcelBot/Global.asax.cs
+++ b/ExcelBot/Global.asax.cs
@@ -3,7 +3,14 @@
  * See LICENSE in the project root for license information.
  */
 
+using Autofac;
+using Microsoft.Bot.Builder.Azure;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Builder.Dialogs.Internals;
+using Microsoft.Bot.Connector;
+using System;
 using System.Configuration;
+using System.Reflection;
 using System.Web.Http;
 
 namespace ExcelBot
@@ -12,6 +19,25 @@ namespace ExcelBot
     {
         protected void Application_Start()
         {
+            // Need to register a bot state data store
+            Conversation.UpdateContainer(
+                builder =>
+                {
+                    builder.RegisterModule(new AzureModule(Assembly.GetExecutingAssembly()));
+
+                    // This will create a CosmosDB store, suitable for production
+                    // NOTE: Requires an actual CosmosDB instance and configuration in
+                    // PrivateSettings.config
+                    var databaseUri = new Uri(ConfigurationManager.AppSettings["Database.Uri"]);
+                    var databaseKey = ConfigurationManager.AppSettings["Database.Key"];
+                    var store = new DocumentDbBotDataStore(databaseUri, databaseKey);
+
+                    builder.Register(c => store)
+                        .Keyed<IBotDataStore<BotData>>(AzureModule.Key_DataStore)
+                        .AsSelf()
+                        .SingleInstance();
+                });
+
             GlobalConfiguration.Configure(WebApiConfig.Register);
         }
     }

--- a/ExcelBot/Helpers/BotStateHelper.cs
+++ b/ExcelBot/Helpers/BotStateHelper.cs
@@ -1,0 +1,72 @@
+﻿/* 
+ * Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+ * See LICENSE in the project root for license information.
+ */
+
+using Microsoft.Azure.Documents;
+using Microsoft.Azure.Documents.Client;
+using Microsoft.Bot.Connector;
+using System;
+using System.Configuration;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace ExcelBot.Helpers
+{
+    public static class BotStateHelper
+    {
+        private static readonly string databaseUri = ConfigurationManager.AppSettings["Database.Uri"];
+        private static readonly string databaseKey = ConfigurationManager.AppSettings["Database.Key"];
+
+        private static readonly string databaseId = "botdb";
+        private static readonly string collectionId = "botcollection";
+
+        private static DocumentClient client = null;
+
+        private static void EnsureClient()
+        {
+            if (client == null)
+            {
+                client = new DocumentClient(new Uri(databaseUri), databaseKey);
+            }
+        }
+
+        public static async Task<BotData> GetUserDataAsync(string channelId, string userId)
+        {
+            // Construct user doc id
+            string userDocId = string.Format("{0}:user{1}", channelId, userId);
+
+            return await GetDocumentAsync(userDocId);
+        }
+
+        public static async Task<BotData> GetConversationDataAsync(string channelId, string conversationId)
+        {
+            // Construct user doc id
+            string conversationDocId = string.Format("{0}:conversation{1}", channelId, conversationId);
+
+            return await GetDocumentAsync(conversationDocId);
+        }
+
+        private static async Task<BotData> GetDocumentAsync(string docId)
+        {
+            EnsureClient();
+
+            try
+            {
+                Document document = await client.ReadDocumentAsync(
+                    UriFactory.CreateDocumentUri(databaseId, collectionId, docId));
+
+                return (BotData)(dynamic)document;
+            }
+            catch (DocumentClientException ex)
+            {
+                if (HttpStatusCode.NotFound == ex.StatusCode)
+                {
+                    return null;
+                }
+
+                throw;
+            }
+        }
+    }
+}

--- a/ExcelBot/Helpers/ServicesHelper.cs
+++ b/ExcelBot/Helpers/ServicesHelper.cs
@@ -105,11 +105,8 @@ namespace ExcelBot.Helpers
         #endregion
 
         #region Methods
-        public static void StartLogging(Activity activity)
+        public static void StartLogging(bool verbose)
         {
-            var stateClient = activity.GetStateClient();
-            var conversationData = stateClient.BotState.GetConversationData(activity.ChannelId, activity.Conversation.Id);
-            var verbose = conversationData.GetProperty<bool>("Verbose");
             if (verbose)
             {
                 UserService.RequestViewModel = new RequestViewModel();

--- a/ExcelBot/PrivateSettings.config.example
+++ b/ExcelBot/PrivateSettings.config.example
@@ -2,8 +2,14 @@
   <!-- update these with your BotId, Microsoft App Id and your Microsoft App Password-->
   <add key="MicrosoftAppId" value="BOT APP ID" />
   <add key="MicrosoftAppPassword" value="BOT APP PASSWORD" />
+
   <!-- update these with your app ID registration information -->
   <add key="ActiveDirectory.ClientId" value="AD CLIENT ID" />
   <add key="ActiveDirectory.ClientSecret" value="AD CLIENT SECRET" />
   <add key="ActiveDirectory.RedirectUrl" value="https://BOT HOST NAME/callback" />
+
+  <!-- update these with your Cosmos DB URI and key -->
+  <!-- example value are for the Cosmos DB Emulator-->
+  <add key="Database.Uri" value="https://localhost:8081"/>
+  <add key="Database.Key" value="C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=="/>
 </appSettings>

--- a/ExcelBot/Web.config
+++ b/ExcelBot/Web.config
@@ -6,6 +6,10 @@
   http://go.microsoft.com/fwlink/?LinkId=301879
   -->
 <configuration>
+  <configSections>
+    <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
+    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+  </configSections>
   <appSettings file="PrivateSettings.config">
     <!-- AAD Auth v1 settings -->
     <add key="ActiveDirectory.Mode" value="v1" />
@@ -22,7 +26,7 @@
       </system.Web>
   -->
   <system.web>
-    <customErrors mode="Off" /> 
+    <customErrors mode="Off" />
     <compilation debug="true" targetFramework="4.6" />
     <httpRuntime targetFramework="4.6" requestPathInvalidCharacters="&lt;,&gt;,&amp;,\,?" />
     <httpModules>
@@ -36,21 +40,20 @@
         <add value="default.htm" />
       </files>
     </defaultDocument>
-    
-  
-  <validation validateIntegratedModeConfiguration="false" />
-  <modules>
-  <remove name="TelemetryCorrelationHttpModule" />
-  <add name="TelemetryCorrelationHttpModule" type="Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation" preCondition="integratedMode,managedHandler" />
-  <remove name="ApplicationInsightsWebTracking" />
-  <add name="ApplicationInsightsWebTracking" type="Microsoft.ApplicationInsights.Web.ApplicationInsightsHttpModule, Microsoft.AI.Web" preCondition="managedHandler" />
-  </modules>
-  <handlers>
+    <validation validateIntegratedModeConfiguration="false" />
+    <modules>
+      <remove name="TelemetryCorrelationHttpModule" />
+      <add name="TelemetryCorrelationHttpModule" type="Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation" preCondition="integratedMode,managedHandler" />
+      <remove name="ApplicationInsightsWebTracking" />
+      <add name="ApplicationInsightsWebTracking" type="Microsoft.ApplicationInsights.Web.ApplicationInsightsHttpModule, Microsoft.AI.Web" preCondition="managedHandler" />
+    </modules>
+    <handlers>
       <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
       <remove name="OPTIONSVerbHandler" />
       <remove name="TRACEVerbHandler" />
       <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
-    </handlers></system.webServer>
+    </handlers>
+  </system.webServer>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
@@ -145,6 +148,20 @@
         <assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-5.2.1.0" newVersion="5.2.1.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Azure.Documents.Client" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.11.0.0" newVersion="1.11.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
+  <entityFramework>
+    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
+      <parameters>
+        <parameter value="mssqllocaldb" />
+      </parameters>
+    </defaultConnectionFactory>
+    <providers>
+      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
+    </providers>
+  </entityFramework>
 </configuration>

--- a/ExcelBot/Workers/ChartsWorker.cs
+++ b/ExcelBot/Workers/ChartsWorker.cs
@@ -117,7 +117,14 @@ namespace ExcelBot.Workers
                 // Replay with chart URL attached
                 var reply = context.MakeMessage();
                 reply.Recipient.Id = (reply.Recipient.Id != null) ? reply.Recipient.Id : (string)(HttpContext.Current.Items["UserId"]);
-                reply.Attachments.Add(new Attachment() { ContentType = "image/png", ContentUrl = $"{RequestHelper.RequestUri.Scheme}://{RequestHelper.RequestUri.Authority}/api/{reply.ChannelId}/{reply.Conversation.Id}/{reply.Recipient.Id}/{userNonce}/image" });
+
+                var image = new Attachment()
+                {
+                    ContentType = "image/png",
+                    ContentUrl = $"{RequestHelper.RequestUri.Scheme}://{RequestHelper.RequestUri.Authority}/api/{reply.ChannelId}/{reply.Conversation.Id}/{reply.Recipient.Id}/{userNonce}/image"
+                };
+
+                reply.Attachments.Add(image);
                 await context.PostAsync(reply);
             }
             catch (Exception ex)

--- a/ExcelBot/packages.config
+++ b/ExcelBot/packages.config
@@ -3,10 +3,12 @@
 <!-- See LICENSE in the project root for license information -->
 <packages>
   <package id="Autofac" version="4.6.2" targetFramework="net46" />
+  <package id="Autofac.WebApi" version="3.1.0" targetFramework="net46" />
   <package id="AutoRest" version="0.17.3" targetFramework="net46" />
   <package id="BotAuth" version="3.11.0-alpha" targetFramework="net46" />
   <package id="BotAuth.AADv2" version="3.11.0-alpha" targetFramework="net46" />
   <package id="Chronic.Signed" version="0.3.2" targetFramework="net46" />
+  <package id="EntityFramework" version="6.1.3" targetFramework="net46" />
   <package id="Microsoft.ApplicationInsights" version="2.5.1" targetFramework="net46" />
   <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.4.0" targetFramework="net46" />
   <package id="Microsoft.ApplicationInsights.DependencyCollector" version="2.5.1" targetFramework="net46" />
@@ -19,8 +21,15 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.4" targetFramework="net46" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.4" targetFramework="net46" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.4" targetFramework="net46" />
+  <package id="Microsoft.Azure.DocumentDB" version="1.18.0" targetFramework="net46" />
+  <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net46" />
   <package id="Microsoft.Bot.Builder" version="3.14.1.1" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder.Azure" version="3.2.5" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder.History" version="3.12.2.4" targetFramework="net46" />
   <package id="Microsoft.Bot.Connector" version="3.14.1.1" targetFramework="net46" />
+  <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net46" />
+  <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net46" />
+  <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Identity.Client" version="1.1.0-preview" targetFramework="net46" />
   <package id="Microsoft.IdentityModel.Logging" version="5.2.1" targetFramework="net46" />
   <package id="Microsoft.IdentityModel.Protocol.Extensions" version="1.0.4.403061554" targetFramework="net46" />
@@ -52,6 +61,7 @@
   <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net46" />
   <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net46" />
   <package id="System.Security.Cryptography.X509Certificates" version="4.3.2" targetFramework="net46" />
+  <package id="System.Spatial" version="5.6.4" targetFramework="net46" />
   <package id="System.Text.Encoding" version="4.3.0" targetFramework="net46" />
   <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net46" />
   <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net46" />
@@ -59,4 +69,5 @@
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net46" />
   <package id="System.Xml.ReaderWriter" version="4.3.1" targetFramework="net46" />
   <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net46" />
+  <package id="WindowsAzure.Storage" version="7.2.1" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
Due to the Bot Framework State Service being shutdown, updated bot to use a CosmosDB database to store state information.

- Added new keys in PrivateSettings.config to specify a database URI and auth key.
- Removed all use of StateClient (it's being deprecated along with the Bot Framework State Service):
    - Where an Activity is available, used pattern described in https://github.com/Microsoft/BotBuilder/issues/4295 to get access to state data.
    - Where no Activity is available, implemented a custom state client that uses the Azure documents client to read the state data directly from the Cosmos DB